### PR TITLE
chore(skaffold): trim dependencies of buildx script

### DIFF
--- a/shell-modules/skaffold.nix
+++ b/shell-modules/skaffold.nix
@@ -13,7 +13,7 @@
         name = "skaffold-buildx-build";
         runtimeInputs = [
           pkgs.coreutils
-          pkgs.docker-client
+          pkgs.docker-buildx
           pkgs.google-cloud-sdk
           pkgs.jq
         ];


### PR DESCRIPTION
The `docker-client` package includes the docker cli, docker-compose, and some other dependencies.  It's safe for us to assume that `skaffold-buildx-build` will only be run in environments where `docker` is already available.

The `docker-buildx` package is just the `docker-buildx` plugin, which is not in github actions runners by default, so it's necessary.
