### PR TITLE
feat(cloud-functions): Support arrays for Google Cloud Function flags

### DIFF
--- a/flake-modules/functions.nix
+++ b/flake-modules/functions.nix
@@ -27,6 +27,7 @@
                       types.nonEmptyStr
                       types.bool
                       types.path
+                      (types.listOf types.nonEmptyStr)
                     ]
                   );
                 };
@@ -59,18 +60,20 @@
                     mergedFlags = flags // {
                       inherit source runtime project;
                     };
-                    flagToString =
+                  in
+                  {
+                    inherit functionName;
+                    deployFlags = lib.flatten (lib.mapAttrsToList (
                       flag: value:
-                      if value == true then
+                      if lib.isList value then
+                        map (v: "--${flag}=${v}") value
+                      else if value == true then
                         "--${flag}"
                       else if value == false then
                         "--no-${flag}"
                       else
-                        "--${flag}=${value}";
-                  in
-                  {
-                    inherit functionName;
-                    deployFlags = lib.mapAttrsToList flagToString mergedFlags;
+                        "--${flag}=${value}"
+                    ) mergedFlags);
                     outPath = builtins.placeholder "out";
                   };
                 text = builtins.readFile ../deploy-function.bash;

--- a/flake-modules/yarn-projects.nix
+++ b/flake-modules/yarn-projects.nix
@@ -68,6 +68,7 @@
                                   types.nonEmptyStr
                                   types.bool
                                   types.path
+                                  (types.listOf types.nonEmptyStr)
                                 ]
                               );
                             };


### PR DESCRIPTION
Why
===
Google Cloud Functions generation 2 requires certain flags like `trigger-event-filters` to be passed multiple times with different values:
```sh
  --trigger-event-filters="type=google.cloud.storage.object.v1.finalized"
  --trigger-event-filters="bucket=my-bucket"
```

The existing Nix module only supported single values (string, bool, path) for flags, causing type errors when users tried to pass arrays:
```nix
  trigger-event-filters = [
    "type=google.cloud.storage.object.v1.finalized"
    "bucket=assets-request-logs"
  ];
```

This prevented proper configuration of event-driven Cloud Functions.

How
===
1. Extended flags type definition to accept `(types.listOf types.nonEmptyStr)` in addition to existing single-value types
2. Updated flag processing logic to handle arrays by using `lib.flatten` with `lib.mapAttrsToList` to convert arrays into multiple flag instances
3. Applied changes to both `functions.nix` and `yarn-projects.nix` modules for consistency

The solution maps:
- `trigger-event-filters = ["a", "b"]` → `["--trigger-event-filters=a", "--trigger-event-filters=b"]`
- Single values continue working unchanged
- Boolean flags remain supported (`true` → `--flag`, `false` → `--no-flag`)

Test Plan
===
1. Nix flake syntax validation: ``` docker run --rm -v "$(pwd):/workspace" -w /workspace nixos/nix \ nix --extra-experimental-features nix-command --extra-experimental-features flakes \ flake check --no-build ```
2. Created test configuration with array flags and verified no type errors
3. Verified existing single-value and boolean flag functionality preserved
4. Manual testing needed: Deploy a function with array flags to validate gcloud CLI receives correct multiple flag arguments (see https://github.com/expo/universe/pull/21484, which motivated this PR)