### PR TITLE
Update nix-direnv version

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -25,7 +25,7 @@ EOM
 	fi
 
 	if has nix; then
-		source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/0357fa09ff68323c472fc0362ddc141a6aa6c3b5/direnvrc" "sha256-RoBVZbAvCb+XYPf2O/jqH64P+hAz55vlUz+cmFNHdDg="
+		source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.7/direnvrc" "sha256-bn8WANE5a91RusFmRI7kS751ApelG02nMcwRekC/qzc="
 		nix_direnv_manual_reload
 
 		NIX_CONFIG="warn-dirty = false


### PR DESCRIPTION
## Why

direnv no longer sets the environment variable `DIRENV_LOG_FORMAT`. When sourcing the `direnvrc` file from https://github.com/nix-community/nix-direnv, this caused issues like below:
```
/Users/byronkarlen/.cache/direnv/cas/46805565b02f09bf9760f7f63bf8ea1fae0ffa1033e79be5533f9c9853477438:18: DIRENV_LOG_FORMAT: unbound variable
direnv: error exit status 1
```

nixdirenv fixed this in release 3.0.7. (see https://github.com/nix-community/nix-direnv/pull/560). 

## How

Updated the source url and hash. 

## Test Plan

Ran `direnv reload` locally.
